### PR TITLE
Include GitHub's raw response

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -27,6 +27,10 @@ module OmniAuth
         }
       end
 
+      extra do
+        {:user_hash => raw_info}
+      end
+
       def raw_info
         access_token.options[:mode] = :query
         @raw_info ||= access_token.get('/user').parsed


### PR DESCRIPTION
Before the move to separate OmniAuth gems for individual strategies, the GitHub strategy included a slew of extra information in the `["extra"]["user_hash"]` hash. This commit brings back those glory days. It's useful for setting a user's gravatar upon registration, amongst many other possibilities.
