### PR TITLE
If scope is nil or 'public', skip email.

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -38,13 +38,18 @@ module OmniAuth
       end
 
       def email
-        raw_info['email'] || emails.first
+        raw_info['email'] || (email_access_allowed? ? emails.first : nil)
       end
 
       def emails
         access_token.options[:mode] = :query
         @emails ||= access_token.get('/user/emails').parsed
       end
+
+      def email_access_allowed?
+        options['scope'] && !(options['scope'] == 'public')
+      end
+
     end
   end
 end

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -18,4 +18,51 @@ describe OmniAuth::Strategies::GitHub do
       subject.options.client_options.token_url.should eq('https://github.com/login/oauth/access_token')
     end
   end
+
+  context "#email_access_allowed?" do
+    it "should not allow email if scope is nil" do
+      subject.options['scope'].should be_nil
+      subject.should_not be_email_access_allowed
+    end
+
+    it "should not allow email if scope is 'public'" do
+      subject.options['scope'] = 'public'
+      subject.should_not be_email_access_allowed
+    end
+
+    it "should allow email if scope is user" do
+      subject.options['scope'] = 'user'
+      subject.should be_email_access_allowed
+    end
+
+    it "should allow email if scope is scope is a bunch of stuff" do
+      subject.options['scope'] = 'user,public_repo,repo,delete_repo,gist'
+      subject.should be_email_access_allowed
+    end
+
+    it "should assume email access allowed if scope is scope is something currently not documented " do
+      subject.options['scope'] = 'currently_not_documented'
+      subject.should be_email_access_allowed
+    end
+  end
+
+  context "#email" do
+    it "should return email from raw_info if available" do
+      subject.stub!(:raw_info).and_return({'email' => 'you@example.com'})
+      subject.email.should eq('you@example.com')
+    end
+
+    it "should return nil if there is no raw_info and email access is not allowed" do
+      subject.stub!(:raw_info).and_return({})
+      subject.email.should be_nil
+    end
+
+    it "should return the first email if there is no raw_info and email access is allowed" do
+      subject.stub!(:raw_info).and_return({})
+      subject.options['scope'] = 'user'
+      subject.stub!(:emails).and_return([ 'you@example.com' ])
+      subject.email.should eq('you@example.com')
+    end
+  end
+
 end


### PR DESCRIPTION
If the scope is nil or 'public', github denies access to the email and
omniauth raises a failure.  This makes it so that if you want to use
github for read-only authentication, you can't (at least in an obvious
fashion).

There is a workaround: pass 'skip_info: true' on configuration.  In this
case you do not get the 'nickname' and 'image', however.
For example, the following will work without this fix:
provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], skip_info:
true

The other solution, without this patch, is to specify at least the user
scope, like so:
provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope:
'user'
