### PR TITLE
UID should be a String

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -13,7 +13,7 @@ module OmniAuth
         super
       end
 
-      uid { raw_info['id'] }
+      uid { raw_info['id'].to_s }
 
       info do
         {


### PR DESCRIPTION
OmniAuth expects to receive UIDs as Strings, but the 'id' field GitHub returns is an integer.

For example PostgreSQL fails to compare a String field (uid) to an integer value.

There aren't any other related specs, so I didn't write them for this change either. It might be a good idea to add some tests with real-world data.
