### PR TITLE
Ability to specify scope on a individual auth request with a URL parameter

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -12,6 +12,14 @@ module OmniAuth
       def request_phase
         super
       end
+      
+      def authorize_params
+        if request.params["scope"]
+          super.merge({:scope => request.params["scope"]})
+        else
+          super
+        end
+      end
 
       uid { raw_info['id'].to_s }
 


### PR DESCRIPTION
I use this in my own app and figure it could be helpful to others. 

Some of my users like to be able to have some control over the scope I request from github.  Pretty simple change, inspired a bit by how omniauth-facebook does it.
