### PR TITLE
email field now returns the user's primary email.

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -46,12 +46,19 @@ module OmniAuth
       end
 
       def email
-        raw_info['email'] || (email_access_allowed? ? emails.first : nil)
+        raw_info['email'] || primary_email
       end
 
+      def primary_email
+        primary = emails.find{|i| i['primary'] }
+        primary && primary['email'] || emails.first && emails.first['email']
+      end
+
+      # The new /user/emails API - http://developer.github.com/v3/users/emails/#future-response
       def emails
+        return [] unless email_access_allowed?
         access_token.options[:mode] = :query
-        @emails ||= access_token.get('/user/emails').parsed
+        @emails ||= access_token.get('/user/emails', :headers => { 'Accept' => 'application/vnd.github.v3' }).parsed
       end
 
       def email_access_allowed?

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -57,11 +57,26 @@ describe OmniAuth::Strategies::GitHub do
       subject.email.should be_nil
     end
 
-    it "should return the first email if there is no raw_info and email access is allowed" do
+    it "should return the primary email if there is no raw_info and email access is allowed" do
+      emails = [
+        { 'email' => 'secondary@example.com', 'primary' => false },
+        { 'email' => 'primary@example.com',   'primary' => true }
+      ]
       subject.stub!(:raw_info).and_return({})
       subject.options['scope'] = 'user'
-      subject.stub!(:emails).and_return([ 'you@example.com' ])
-      subject.email.should eq('you@example.com')
+      subject.stub!(:emails).and_return(emails)
+      subject.email.should eq('primary@example.com')
+    end
+
+    it "should return the first email if there is no raw_info and email access is allowed" do
+      emails = [
+        { 'email' => 'first@example.com',   'primary' => false },
+        { 'email' => 'second@example.com',  'primary' => false }
+      ]
+      subject.stub!(:raw_info).and_return({})
+      subject.options['scope'] = 'user'
+      subject.stub!(:emails).and_return(emails)
+      subject.email.should eq('first@example.com')
     end
   end
 


### PR DESCRIPTION
Today, I received this email from Github:

> Hi, Kenn,
> 
> We're introducing a new media type today to get emails back as an array of hashes[1]. Just use 'application/vnd.github.v3' for your Accept header and check out the caveats[2] on the new media type roll out.
> 
> [1]: http://developer.github.com/v3/users/emails/#future-response
> [2]: http://developer.github.com/v3/media/#api-v3-media-type-and-the-future
> 
> Cheers,

Finally, we are able to support primary email for Omniauth -  I'm sending this pull request to do just that.
