### PR TITLE
Add Github Enterprise Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ on the [GitHub Applications Page](https://github.com/settings/applications).
       provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
     end
 
-### Scopes
+## Github Enterprise Usage
+
+    provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'],
+        {
+          :client_options => {
+            :site => 'https://github.YOURDOMAIN.com/api/v3',
+            :authorize_url => 'https://github.YOURDOMAIN.com/login/oauth/authorize',
+            :token_url => 'https://github.YOURDOMAIN.com/login/oauth/access_token',
+          }
+        }
+
+## Scopes
 
 GitHub API v3 lets you set scopes to provide granular access to different types of data: 
 

--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -14,10 +14,12 @@ module OmniAuth
       end
       
       def authorize_params
-        if request.params["scope"]
-          super.merge({:scope => request.params["scope"]})
-        else
-          super
+        super.tap do |params|
+          %w[scope client_options].each do |v|
+            if request.params[v]
+              params[v.to_sym] = request.params[v]
+            end
+          end
         end
       end
 
@@ -42,7 +44,7 @@ module OmniAuth
 
       def raw_info
         access_token.options[:mode] = :query
-        @raw_info ||= access_token.get('/user').parsed
+        @raw_info ||= access_token.get('user').parsed
       end
 
       def email
@@ -58,7 +60,7 @@ module OmniAuth
       def emails
         return [] unless email_access_allowed?
         access_token.options[:mode] = :query
-        @emails ||= access_token.get('/user/emails', :headers => { 'Accept' => 'application/vnd.github.v3' }).parsed
+        @emails ||= access_token.get('user/emails', :headers => { 'Accept' => 'application/vnd.github.v3' }).parsed
       end
 
       def email_access_allowed?

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -1,8 +1,31 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::GitHub do
+  let(:access_token) { stub('AccessToken', :options => {}) }
+  let(:parsed_response) { stub('ParsedResponse') }
+  let(:response) { stub('Response', :parsed => parsed_response) }
+
+  let(:enterprise_site)          { 'https://some.other.site.com/api/v3' }
+  let(:enterprise_authorize_url) { 'https://some.other.site.com/login/oauth/authorize' }
+  let(:enterprise_token_url)     { 'https://some.other.site.com/login/oauth/access_token' }
+  let(:enterprise) do
+    OmniAuth::Strategies::GitHub.new('GITHUB_KEY', 'GITHUB_SECRET',
+        {
+            :client_options => {
+                :site => enterprise_site,
+                :authorize_url => enterprise_authorize_url,
+                :token_url => enterprise_token_url
+            }
+        }
+    )
+  end
+
   subject do
     OmniAuth::Strategies::GitHub.new({})
+  end
+
+  before(:each) do
+    subject.stub!(:access_token).and_return(access_token)
   end
 
   context "client options" do
@@ -16,6 +39,20 @@ describe OmniAuth::Strategies::GitHub do
 
     it 'should have correct token url' do
       subject.options.client_options.token_url.should eq('https://github.com/login/oauth/access_token')
+    end
+
+    describe "should be overrideable" do
+      it "for site" do
+        enterprise.options.client_options.site.should eq(enterprise_site)
+      end
+
+      it "for authorize url" do
+        enterprise.options.client_options.authorize_url.should eq(enterprise_authorize_url)
+      end
+
+      it "for token url" do
+        enterprise.options.client_options.token_url.should eq(enterprise_token_url)
+      end
     end
   end
 
@@ -77,6 +114,21 @@ describe OmniAuth::Strategies::GitHub do
       subject.options['scope'] = 'user'
       subject.stub!(:emails).and_return(emails)
       subject.email.should eq('first@example.com')
+    end
+  end
+
+  context "#raw_info" do
+    it "should use relative paths" do
+      access_token.should_receive(:get).with('user').and_return(response)
+      subject.raw_info.should eq(parsed_response)
+    end
+  end
+
+  context "#emails" do
+    it "should use relative paths" do
+      access_token.should_receive(:get).with('user/emails', :headers=>{"Accept"=>"application/vnd.github.v3"}).and_return(response)
+      subject.options['scope'] = 'user'
+      subject.emails.should eq(parsed_response)
     end
   end
 


### PR DESCRIPTION
- In addition to scope, client_options can now 
  be passed in to replace the ones hard coded
  in the gem
- Modify GET requests to use relative URLs 
  instead of absolute URLs
- Added specs to verify client_options are 
  correctly overridden and relative URLs are
  utilized

[Fixes #23]
