### PR TITLE
Private email is not returned if the public one is blank

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -48,7 +48,7 @@ module OmniAuth
       end
 
       def email
-        primary_email ? (raw_info['email'].nil? || raw_info['email'].empty?) : primary_email
+         (raw_info['email'].nil? || raw_info['email'].empty?) ? primary_email : raw_info['email']
       end
 
       def primary_email


### PR DESCRIPTION
if you had a public email on github but removed it (empty), then it comes back in raw_info as "" and not nil. This means it is not then replaced with primary_email from the emails API.
