### PR TITLE
Bumped version to 1.1.1.

### DIFF
--- a/lib/omniauth-github/version.rb
+++ b/lib/omniauth-github/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module GitHub
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
Bumped version to 1.1.1 so that the rubygems would use the latest pull request #25 that fixes the blank email issue.
