### PR TITLE
Tweak email to prefer primary email address if available

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -48,7 +48,7 @@ module OmniAuth
       end
 
       def email
-         (raw_info['email'].nil? || raw_info['email'].empty?) ? primary_email : raw_info['email']
+         (email_access_allowed?) ? primary_email : raw_info['email']
       end
 
       def primary_email


### PR DESCRIPTION
Right now, public email address takes precedence over a user's primary email address. This is unfavorable as the public email address is not guaranteed to be an email address (it's just a text field).
