### PR TITLE
bump omniauth-oauth2 dependency version (CSRF issue)

### DIFF
--- a/omniauth-github.gemspec
+++ b/omniauth-github.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::GitHub::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.1'
+  gem.add_dependency 'omniauth', '>= 1.1.1'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.1.1'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
http://www.rubysec.com/advisories/CVE-2012-6134/

```
CVE-2012-6134 in omniauth-oauth2 
Cross-site request forgery (CSRF) vulnerability in the omniauth-oauth2 gem 1.1.1 and earlier for Ruby allows remote attackers to hijack the authentication of users for requests that modify session state.
```
