### PR TITLE
Update omniauth strategy to pass location

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -31,6 +31,7 @@ module OmniAuth
           'email' => email,
           'name' => raw_info['name'],
           'image' => raw_info['avatar_url'],
+          'location' => raw_info['location']
           'urls' => {
             'GitHub' => raw_info['html_url'],
             'Blog' => raw_info['blog'],

--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -31,7 +31,7 @@ module OmniAuth
           'email' => email,
           'name' => raw_info['name'],
           'image' => raw_info['avatar_url'],
-          'location' => raw_info['location']
+          'location' => raw_info['location'],
           'urls' => {
             'GitHub' => raw_info['html_url'],
             'Blog' => raw_info['blog'],


### PR DESCRIPTION
Adding additional `location` field from `raw_info` to the object that is created so that it better fits into Omniauth's Auto Hash Schema