### PR TITLE
Include the received access token's scope in the 'extra' hash

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -39,7 +39,7 @@ module OmniAuth
       end
 
       extra do
-        {:raw_info => raw_info, :all_emails => emails}
+        {:raw_info => raw_info, :all_emails => emails, :scope => scope }
       end
 
       def raw_info
@@ -49,6 +49,10 @@ module OmniAuth
 
       def email
         (email_access_allowed?) ? primary_email : raw_info['email']
+      end
+
+      def scope
+        access_token['scope']
       end
 
       def primary_email

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::GitHub do
-  let(:access_token) { instance_double('AccessToken', :options => {}) }
+  let(:access_token) { instance_double('AccessToken', :options => {}, :[] => 'user') }
   let(:parsed_response) { instance_double('ParsedResponse') }
   let(:response) { instance_double('Response', :parsed => parsed_response) }
 
@@ -147,6 +147,12 @@ describe OmniAuth::Strategies::GitHub do
     it 'should use html_url from raw_info' do
       allow(subject).to receive(:raw_info).and_return({ 'login' => 'me', 'html_url' => 'http://enterprise/me' })
       expect(subject.info['urls']['GitHub']).to eq('http://enterprise/me')
+    end
+  end
+
+  context '#extra.scope' do
+    it 'returns the scope on the returned access_token' do
+      expect(subject.scope).to eq('user')
     end
   end
 


### PR DESCRIPTION
According to [GitHub's documentation](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#requested-scopes-and-granted-scopes):

> The scope attribute lists scopes attached to the token that were granted
> by the user. Normally, these scopes will be identical to what you
> requested. However, users can edit their scopes, effectively granting
> your application less access than you originally requested. Also, users
> can edit token scopes after the OAuth flow is completed. You should be
> aware of this possibility and adjust your application's behavior
> accordingly.

Therefore, include the scope returned with the OAuth token in the
'extra' hash generated for the omniauth callback.

According to the OAuth2 gem's code, extra params returned with the
access token response can accessed via indexing on the AccessToken
class:

https://github.com/oauth-xx/oauth2/blob/58471c95c5473d9a494e45534df96f0cf935a2bb/lib/oauth2/access_token.rb#L60-L65