### PR TITLE
Use header auth mode for user and email requests

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -43,7 +43,7 @@ module OmniAuth
       end
 
       def raw_info
-        access_token.options[:mode] = :query
+        access_token.options[:mode] = :header
         @raw_info ||= access_token.get('user').parsed
       end
 
@@ -59,7 +59,7 @@ module OmniAuth
       # The new /user/emails API - http://developer.github.com/v3/users/emails/#future-response
       def emails
         return [] unless email_access_allowed?
-        access_token.options[:mode] = :query
+        access_token.options[:mode] = :header
         @emails ||= access_token.get('user/emails', :headers => { 'Accept' => 'application/vnd.github.v3' }).parsed
       end
 

--- a/spec/omniauth/strategies/github_spec.rb
+++ b/spec/omniauth/strategies/github_spec.rb
@@ -122,6 +122,12 @@ describe OmniAuth::Strategies::GitHub do
       expect(access_token).to receive(:get).with('user').and_return(response)
       expect(subject.raw_info).to eq(parsed_response)
     end
+
+    it 'should use the header auth mode' do
+      expect(access_token).to receive(:get).with('user').and_return(response)
+      subject.raw_info
+      expect(access_token.options[:mode]).to eq(:header)
+    end
   end
 
   context '#emails' do
@@ -132,6 +138,16 @@ describe OmniAuth::Strategies::GitHub do
 
       subject.options['scope'] = 'user'
       expect(subject.emails).to eq(parsed_response)
+    end
+
+    it 'should use the header auth mode' do
+      expect(access_token).to receive(:get).with('user/emails', :headers => {
+        'Accept' => 'application/vnd.github.v3'
+      }).and_return(response)
+
+      subject.options['scope'] = 'user'
+      subject.emails
+      expect(access_token.options[:mode]).to eq(:header)
     end
   end
 


### PR DESCRIPTION
Fixes #83 - authenticating using query parameters is deprecated:

https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters