### PR TITLE
Install from Rubygems, not from GitHub [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ on the [GitHub Applications Page](https://github.com/settings/applications).
 ## Installation
 
 ```ruby
-gem 'omniauth-github', github: 'omniauth/omniauth-github', branch: 'master'
+gem 'omniauth-github', '~> 1.4.0'
 ```
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ on the [GitHub Applications Page](https://github.com/settings/applications).
 ## Installation
 
 ```ruby
-gem 'omniauth-github', '~> 1.4.0'
+gem 'omniauth-github', '~> 2.0.0'
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Installation from GitHub master can introduce some problems,
and since `1.4.0` was released in February and master branch has a few commits from it,
it should be fine to simply install `~> 1.4.0`.