### PR TITLE
Add Ruby 2.7, 3.0, and 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', 'truffleruby-head']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', 'truffleruby-head']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 2.7, 3.0, and 3.1 to the CI matrix.  EOLed Rubies were left in place.

Also switches to the going-forward supported action for installing Ruby in GitHub Actions.