### PR TITLE
Upgrade omniauth-oauth2 dependency

### DIFF
--- a/omniauth-github.gemspec
+++ b/omniauth-github.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::GitHub::VERSION
 
   gem.add_dependency 'omniauth', '~> 2.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.8'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
* `omniauth-oauth2 ~> 1.7.1` has as more relaxed omniauth dependency, but this gem requires `omniauth ~> 2.0` anyway so upgrading to `omniauth-oauth ~> 1.8` will not be a breaking change
* Diff: https://my.diffend.io/gems/omniauth-oauth2/1.7.1/1.8.0